### PR TITLE
Add support for Ubuntu LTS

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,8 @@
 ---
 driver:
   name: docker
+  driver_config:
+    use_sudo: false
 
 provisioner:
   name: chef_zero
@@ -15,8 +17,8 @@ verifier:
 
 platforms:
   - name: debian
-    driver_config:
-      use_sudo: false
+  - name: ubuntu
+  - name: ubuntu-18.04
 
 suites:
   - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: required
-dist: trusty
+dist: focal
 group: edge # https://github.com/travis-ci/travis-ci/issues/5448
 services:
   - docker

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ end
 
 group :style do
   gem 'cookstyle'
-  gem 'foodcritic'
 end
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -7,16 +7,10 @@ namespace :style do
     task.options << '--extra-details'
     task.options << '--display-style-guide'
   end
-
-  desc 'Run Chef style checks'
-  require 'foodcritic'
-  FoodCritic::Rake::LintTask.new(:chef) do |task|
-    task.options[:fail_tags] = ['any']
-  end
 end
 
 desc 'Run all style checks'
-task style: ['style:ruby', 'style:chef']
+task style: ['style:ruby']
 
 require 'kitchen/rake_tasks'
 Kitchen::RakeTasks.new

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 # XXX: see https://fluentbit.io/download/ for latest version
-default['fluentbit']['version'] = '1.4.2'
-default['fluentbit']['checksum'] = '97517c4642bb07c848c25c4a86c72219f91104a0f20a1e9b9cd74c6a3db1a011'
+default['fluentbit']['version'] = '1.6.10'
+default['fluentbit']['checksum'] = 'd5101f31e1aadd5b5df769957651e59d0996df719c1be8219b70cf32ed9ad92e'
 default['fluentbit']['archive'] = "fluent-bit-#{default['fluentbit']['version']}.tar.gz"
 default['fluentbit']['url'] = "https://fluentbit.io/releases/#{default['fluentbit']['version'].split('.')[0..-2].join('.')}/#{default['fluentbit']['archive']}"
 
@@ -8,6 +8,7 @@ default['fluentbit']['dependencies'] = %w(make cmake g++ pkg-config bison flex)
 default['fluentbit']['dependencies'] << 'libsystemd-dev' # required for systemd input plugin
 default['fluentbit']['uninstall_dependencies'] = true # clean up deps after installation?
 default['fluentbit']['make_flags'] = '-j $(nproc)'
+default['fluentbit']['cmake_flags'] = '-DFLB_IN_HTTP=no' # https://github.com/fluent/fluent-bit/issues/2930
 
 default['fluentbit']['install_dir'] = '/usr/local/bin'
 default['fluentbit']['conf_dir'] = '/etc/fluent-bit'

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,3 +10,4 @@ version          '1.4.2'
 chef_version     '>= 14.0'
 
 supports 'debian'
+supports 'ubuntu'

--- a/recipes/forward.rb
+++ b/recipes/forward.rb
@@ -25,8 +25,9 @@ fluentbit_conf 'forward' do
         Tag    #{node['fluentbit']['forward']['tag_prefix']}kmsg
 
     [INPUT]
-        Name   systemd
-        Tag    #{node['fluentbit']['forward']['tag_prefix']}systemd
+        Name            systemd
+        Tag             #{node['fluentbit']['forward']['tag_prefix']}systemd
+        Read_From_Tail  On
 
     # XXX: Example with Monit:
     #

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -35,7 +35,7 @@ bash 'install_fluentbit' do
     set -eux
     tar xf #{node['fluentbit']['archive']}
     cd fluent-bit-#{node['fluentbit']['version']}/build
-    cmake ..
+    cmake .. #{node['fluentbit']['cmake_flags']}
     make #{node['fluentbit']['make_flags']}
     install --strip -m 0755 -t #{node['fluentbit']['install_dir']} bin/fluent-bit
   BASH


### PR DESCRIPTION
The cookbook should support Ubuntu LTS (18.04, 20.04) too!
This is as trivial as adding a test suite since Fluentbit is platform independant and Debian is very close.