### PR TITLE
Install from binary packages

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,6 +11,10 @@ provisioner:
   deprecations_as_errors: true
   multiple_converge: 2
   enforce_idempotency: true
+  attributes:
+    fluentbit:
+      conf:
+        Daemon: "On"
 
 verifier:
   name: inspec
@@ -27,5 +31,11 @@ suites:
       - recipe[fluentbit::_example]
     attributes:
       fluentbit:
-        conf:
-          Daemon: "On"
+        install_mode: "package"
+  - name: source
+    run_list:
+      - recipe[fluentbit::install]
+      - recipe[fluentbit::_example]
+    attributes:
+      fluentbit:
+        install_mode: "source"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 The recipe `fluentbit::default` installs [Fluent Bit](http://fluentbit.io).
 
+You can select whether to install the binary packages provided by Treasure Data (TD Agent bit) or compile Fluent Bit from source.
+
+```ruby
+override['fluentbit']['install_mode'] = 'package' # the default
+override['fluentbit']['install_mode'] = 'source' # build from source code
+```
+
 You can add custom configuration with the `fluentbit_conf` helper:
 
 ```ruby

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,17 +13,10 @@ default['fluentbit']['cmake_flags'] = '-DFLB_IN_HTTP=no' # https://github.com/fl
 
 default['fluentbit']['install_mode'] = 'package'
 
-if node['fluentbit']['install_mode'] == 'package'
-  default['fluentbit']['install_dir'] = '/opt/td-agent-bit/bin'
-  default['fluentbit']['service_name'] = 'td-agent-bit'
-  default['fluentbit']['conf_dir'] = '/etc/td-agent-bit'
-  default['fluentbit']['lib_dir'] = '/lib/td-agent-bit'
-else
-  default['fluentbit']['install_dir'] = '/usr/local/bin'
-  default['fluentbit']['service_name'] = 'fluent-bit'
-  default['fluentbit']['conf_dir'] = '/etc/fluent-bit'
-  default['fluentbit']['lib_dir'] = '/var/lib/fluent-bit'
-end
+default['fluentbit']['install_dir'] = '/opt/td-agent-bit/bin'
+default['fluentbit']['service_name'] = 'td-agent-bit'
+default['fluentbit']['conf_dir'] = '/etc/td-agent-bit'
+default['fluentbit']['lib_dir'] = '/lib/td-agent-bit'
 
 default['fluentbit']['conf']['Flush'] = 5
 default['fluentbit']['conf']['Daemon'] = 'Off'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 # XXX: see https://fluentbit.io/download/ for latest version
+# Only used for source install mode
 default['fluentbit']['version'] = '1.6.10'
 default['fluentbit']['checksum'] = 'd5101f31e1aadd5b5df769957651e59d0996df719c1be8219b70cf32ed9ad92e'
 default['fluentbit']['archive'] = "fluent-bit-#{default['fluentbit']['version']}.tar.gz"
@@ -6,12 +7,23 @@ default['fluentbit']['url'] = "https://fluentbit.io/releases/#{default['fluentbi
 
 default['fluentbit']['dependencies'] = %w(make cmake g++ pkg-config bison flex)
 default['fluentbit']['dependencies'] << 'libsystemd-dev' # required for systemd input plugin
-default['fluentbit']['uninstall_dependencies'] = true # clean up deps after installation?
+default['fluentbit']['uninstall_dependencies'] = true # clean up deps after source installation?
 default['fluentbit']['make_flags'] = '-j $(nproc)'
 default['fluentbit']['cmake_flags'] = '-DFLB_IN_HTTP=no' # https://github.com/fluent/fluent-bit/issues/2930
 
-default['fluentbit']['install_dir'] = '/usr/local/bin'
-default['fluentbit']['conf_dir'] = '/etc/fluent-bit'
+default['fluentbit']['install_mode'] = 'package'
+
+if node['fluentbit']['install_mode'] == 'package'
+  default['fluentbit']['install_dir'] = '/opt/td-agent-bit/bin'
+  default['fluentbit']['service_name'] = 'td-agent-bit'
+  default['fluentbit']['conf_dir'] = '/etc/td-agent-bit'
+  default['fluentbit']['lib_dir'] = '/lib/td-agent-bit'
+else
+  default['fluentbit']['install_dir'] = '/usr/local/bin'
+  default['fluentbit']['service_name'] = 'fluent-bit'
+  default['fluentbit']['conf_dir'] = '/etc/fluent-bit'
+  default['fluentbit']['lib_dir'] = '/var/lib/fluent-bit'
+end
 
 default['fluentbit']['conf']['Flush'] = 5
 default['fluentbit']['conf']['Daemon'] = 'Off'

--- a/recipes/forward.rb
+++ b/recipes/forward.rb
@@ -8,14 +8,14 @@ file "#{node['fluentbit']['conf_dir']}/cert.pem" do
   group 'root'
   mode '0400'
   content node['fluentbit']['forward'].fetch('cert')
-  notifies :restart, 'systemd_unit[fluent-bit.service]'
+  notifies :restart, "service[#{node['fluentbit']['service_name']}]"
 end
 
-directory '/var/lib/fluent-bit' do
+directory node['fluentbit']['lib_dir'] do
   owner 'root'
   group 'root'
   mode '0755'
-  notifies :restart, 'systemd_unit[fluent-bit.service]'
+  notifies :restart, "service[#{node['fluentbit']['service_name']}]"
 end
 
 fluentbit_conf 'forward' do

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -3,8 +3,7 @@
 # Recipe:: install
 #
 
-include_recipe "#{cookbook_name}::install_package" if node['fluentbit']['install_mode'] == 'package'
-include_recipe "#{cookbook_name}::install_source" if node['fluentbit']['install_mode'] == 'source'
+include_recipe "#{cookbook_name}::install_#{node['fluentbit']['install_mode']}"
 
 template "#{node['fluentbit']['conf_dir']}/#{node['fluentbit']['service_name']}.conf" do
   action :create_if_missing
@@ -32,7 +31,7 @@ template "#{node['fluentbit']['conf_dir']}/_service.conf" do
   notifies :restart, "service[#{node['fluentbit']['service_name']}]"
 end
 
-systemd_unit node['fluentbit']['service_name'] do
+systemd_unit "#{node['fluentbit']['service_name']}.service" do
   content <<-UNIT
     [Unit]
     Description=Fluent Bit
@@ -48,8 +47,8 @@ systemd_unit node['fluentbit']['service_name'] do
     WantedBy=multi-user.target
   UNIT
 
-  action :create
-  only_if { node['fluentbit']['install_mode'] == 'source' && node['init_package'] == 'systemd' } # XXX: skip with Docker
+  action %w(create enable)
+  only_if { node['init_package'] == 'systemd' } # XXX: skip with Docker
   notifies :restart, "service[#{node['fluentbit']['service_name']}]"
 end
 

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -1,0 +1,28 @@
+#
+# Cookbook:: fluentbit
+# Recipe:: install_package
+#
+
+# $ wget -qO - https://packages.fluentbit.io/fluentbit.key | sudo apt-key add -
+
+package 'gnupg2'
+
+apt_repository 'fluentbit' do
+  uri "https://packages.fluentbit.io/#{node['platform']}/#{node['lsb']['codename']}"
+  components ['main']
+  key 'https://packages.fluentbit.io/fluentbit.key'
+  keyserver false
+end
+
+package 'td-agent-bit' do
+  notifies :run, 'execute[Rename td-agent-bit dist config]', :immediate
+end
+
+# Rename the dist config file that will get replaced by our own
+execute 'Rename td-agent-bit dist config' do
+  action :nothing
+  command 'mv td-agent-bit.conf td-agent-bit.conf.dist'
+  cwd node['fluentbit']['conf_dir']
+  not_if ::File.exist? "#{node['fluentbit']['conf_dir']}/td-agent-bit.conf.dist"
+  only_if ::File.exist? "#{node['fluentbit']['conf_dir']}/td-agent-bit.conf"
+end

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -15,7 +15,7 @@ apt_repository 'fluentbit' do
 end
 
 package 'td-agent-bit' do
-  notifies :run, 'execute[Rename td-agent-bit dist config]', :immediate
+  notifies :run, 'execute[Rename td-agent-bit dist config]', :immediately
 end
 
 # Rename the dist config file that will get replaced by our own

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -3,6 +3,11 @@
 # Recipe:: install_source
 #
 
+node.force_default['fluentbit']['install_dir'] = '/usr/local/bin'
+node.force_default['fluentbit']['service_name'] = 'fluent-bit'
+node.force_default['fluentbit']['conf_dir'] = '/etc/fluent-bit'
+node.force_default['fluentbit']['lib_dir'] = '/var/lib/fluent-bit'
+
 remote_file "#{Chef::Config[:file_cache_path]}/#{node['fluentbit']['archive']}" do
   source node['fluentbit']['url']
   checksum node['fluentbit']['checksum']

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -1,0 +1,55 @@
+#
+# Cookbook:: fluentbit
+# Recipe:: install_source
+#
+
+remote_file "#{Chef::Config[:file_cache_path]}/#{node['fluentbit']['archive']}" do
+  source node['fluentbit']['url']
+  checksum node['fluentbit']['checksum']
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :install, 'package[install_dependencies]', :immediately
+  notifies :run, 'bash[install_fluentbit]', :immediately
+  notifies :purge, 'package[uninstall_dependencies]', :immediately
+end
+
+# Force update packages before installing
+apt_update 'update' do
+  action :nothing
+end
+
+package 'install_dependencies' do
+  action :nothing
+  package_name node['fluentbit']['dependencies']
+  notifies :update, 'apt_update[update]', :before
+end
+
+package 'uninstall_dependencies' do
+  action :nothing
+  package_name node['fluentbit']['dependencies']
+  options '--auto-remove'
+  only_if { node['fluentbit']['uninstall_dependencies'] }
+end
+
+bash 'install_fluentbit' do
+  action :nothing
+  user 'root'
+  group 'root'
+  cwd Chef::Config[:file_cache_path]
+  code <<-BASH
+    set -eux
+    tar xf #{node['fluentbit']['archive']}
+    cd fluent-bit-#{node['fluentbit']['version']}/build
+    cmake .. #{node['fluentbit']['cmake_flags']}
+    make #{node['fluentbit']['make_flags']}
+    install --strip -m 0755 -t #{node['fluentbit']['install_dir']} bin/fluent-bit
+  BASH
+  notifies :restart, "service[#{node['fluentbit']['service_name']}]"
+end
+
+directory node['fluentbit']['conf_dir'] do
+  owner 'root'
+  group 'root'
+  mode '0755'
+end

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -16,7 +16,7 @@ end
 def include_file(resource)
   case resource.type
   when :conf
-    "#{node['fluentbit']['conf_dir']}/fluent-bit.conf"
+    "#{node['fluentbit']['conf_dir']}/#{node['fluentbit']['service_name']}.conf"
   when :parser
     "#{node['fluentbit']['conf_dir']}/_service.conf"
   else raise
@@ -39,7 +39,7 @@ action :create do
     group 'root'
     mode '0400'
     content new_resource.content
-    notifies :restart, 'systemd_unit[fluent-bit.service]'
+    notifies :restart, "service[#{node['fluentbit']['service_name']}]"
   end
 
   line = include_line new_resource
@@ -50,14 +50,14 @@ action :create do
     group 'root'
     not_if "grep -E '^#{line}' #{file}"
     command "echo '#{line}' >> #{file}"
-    notifies :restart, 'systemd_unit[fluent-bit.service]'
+    notifies :restart, "service[#{node['fluentbit']['service_name']}]"
   end
 end
 
 action :delete do
   file conf_file(new_resource) do
     action :delete
-    notifies :restart, 'systemd_unit[fluent-bit.service]'
+    notifies :restart, "service[#{node['fluentbit']['service_name']}]"
   end
 
   ruby_block "delete #{include_line new_resource}" do

--- a/test/integration/default/inspec/fluentbit_spec.rb
+++ b/test/integration/default/inspec/fluentbit_spec.rb
@@ -1,26 +1,21 @@
-control 'fluentbit-1' do
+control 'fluentbit-package-install' do
   title 'fluentbit'
   impact 1.0
 
-  describe file('/etc/fluent-bit/fluent-bit.conf') do
+  describe file('/etc/td-agent-bit/td-agent-bit.conf') do
     it { should be_file }
   end
 
-  describe file('/etc/fluent-bit/parsers-foo.conf') do
+  describe file('/etc/td-agent-bit/parsers-foo.conf') do
     it { should be_file }
   end
 
-  describe file('/usr/local/bin/fluent-bit') do
+  describe file('/opt/td-agent-bit/bin/td-agent-bit') do
     it { should be_file }
   end
 
-  describe command('fluent-bit --config /etc/fluent-bit/fluent-bit.conf') do
+  describe command('/opt/td-agent-bit/bin/td-agent-bit --config /etc/td-agent-bit/td-agent-bit.conf') do
     its('stderr') { should match 'Fluent Bit' }
     its('stderr') { should match 'switching to background mode' }
-  end
-
-  describe package('cmake-data') do
-    # XXX: Make sure we auto-remove dependencies of the build dependencies
-    it { should_not be_installed }
   end
 end

--- a/test/integration/source/inspec/fluentbit_spec.rb
+++ b/test/integration/source/inspec/fluentbit_spec.rb
@@ -1,0 +1,26 @@
+control 'fluentbit-source-install' do
+  title 'fluentbit'
+  impact 1.0
+
+  describe file('/etc/fluent-bit/fluent-bit.conf') do
+    it { should be_file }
+  end
+
+  describe file('/etc/fluent-bit/parsers-foo.conf') do
+    it { should be_file }
+  end
+
+  describe file('/usr/local/bin/fluent-bit') do
+    it { should be_file }
+  end
+
+  describe command('fluent-bit --config /etc/fluent-bit/fluent-bit.conf') do
+    its('stderr') { should match 'Fluent Bit' }
+    its('stderr') { should match 'switching to background mode' }
+  end
+
+  describe package('cmake-data') do
+    # XXX: Make sure we auto-remove dependencies of the build dependencies
+    it { should_not be_installed }
+  end
+end


### PR DESCRIPTION
This PR adds the feature suggested in #2, the ability using the `override['fluentbit']['install_mode']` node attribute to select whether to install Fluentbit from the stable Linux packages provided by Treasure Data (speed up converge) or building from source as previously. 

NB: the service in the package distribution installs a binary and systemd service named `td-agent-bit` as well a configuration in `/etc/td-agent-bit` so I had to make that adaptative in the recipes and added a separate test suite.